### PR TITLE
Add support for Mercurial repositories.

### DIFF
--- a/src/autodoc/params.clj
+++ b/src/autodoc/params.clj
@@ -32,6 +32,7 @@
       
       [:page-title nil "A title to put on each page"],
       [:copyright "No copyright info " "Copyright (or other page footer data) to put at the bottom of each page"]
+      [:scm-tool "git" "Source control management tool: git or hg"]
       [:commit? false "Commit and push the documentation when complete, if doc dir is a git repo"]
       ])
 
@@ -53,9 +54,19 @@
        (doseq [[kw _ desc] available-params :when desc]
          (println (str "   --" (name kw) ": " desc))))))
 
+(defn check-params
+  "Check the param map to make sure its values are legal"
+  [param-map]
+  (do
+    (when-let [tool (param-map :scm-tool)]
+      (when-not (contains? #{"git" "hg"} tool)
+        (throw (IllegalArgumentException. "Parameter :scm-tool can only be git or hg"))))
+    nil))
+
 (defn merge-params 
   "Merge the param map supplied into the params defined in the params var"
   [param-map]
+  (check-params param-map)
   (alter-var-root #'params merge param-map))
 
 (defn params-from-dir 


### PR DESCRIPTION
Add a :scm-tool key to the parameters map to allow the user to specify
their preferred Source Control Management Tool: "git" (default) or "hg".

Modified the code to build HTML with links to source code appropriate to
the chosen SCM tool; e.g. "foo.clj#L99" for git and "foo.clj#cl-99" for hg.
