### PR TITLE
Add option to emit a comprehensive index of the namespace metadata

### DIFF
--- a/src/autodoc/build_html.clj
+++ b/src/autodoc/build_html.clj
@@ -23,6 +23,7 @@
 (def ^:dynamic *sub-namespace-api-file* "sub-namespace-api.html")
 (def ^:dynamic *index-html-file* "api-index.html")
 (def ^:dynamic *index-clj-file* "index~@[-~a~].clj")
+(def ^:dynamic *raw-index-clj-file* "raw-index~@[-~a~].clj")
 (def ^:dynamic *index-json-file* "api-index.json")
 
 (defn template-for
@@ -545,6 +546,13 @@ vars in ns-info that begin with that letter"
     (binding [*out* out]
       (pprint (structured-index ns-info (:name branch-info))))))
 
+(defn make-raw-index-clj [ns-info branch-info]
+  (with-open [out (writer (file (params :output-path)
+                                (cl-format nil *raw-index-clj-file*
+                                           (:version branch-info))))]
+    (binding [*out* out]
+      (pprint ns-info))))
+
 (defn make-index-json
   "Generate a json formatted index file that can be consumed by other tools"
   [ns-info branch-info]
@@ -624,5 +632,7 @@ vars in ns-info that begin with that letter"
            (make-ns-page true (first ns-info) master-toc external-docs branch-info prefix))
          (make-index-html ns-info master-toc branch-info prefix)
          (make-index-clj ns-info branch-info)
+         (when (params :build-raw-index)
+           (make-raw-index-clj ns-info branch-info))
          (make-index-json ns-info branch-info)))))
 

--- a/src/autodoc/params.clj
+++ b/src/autodoc/params.clj
@@ -31,6 +31,7 @@
       [:branches [[nil {}]] nil]
       [:load-except-list [] "A list of regexps that describe files that shouldn't be loaded"], 
       [:build-json-index false "Set to true if you want to create an index file in JSON (currently slow)"],
+      [:build-raw-index false "Set to true if you want to create an index that contains all of the namespace metadata used to generate the docs (suitable for feeding to autodoc's internal functions)"]
       
       [:page-title nil "A title to put on each page"],
       [:copyright "No copyright info " "Copyright (or other page footer data) to put at the bottom of each page"]


### PR DESCRIPTION
This makes it easier to generate a single autodoc/ tree in a multiproject maven build, since the existing index.clj doesn't contain enough data to feed back to autodoc.build-html/make-all-pages. 

Example usage: we use this in Immutant (http://immutant.org/) to build docs for each module, then discard all but the raw indexes, which are fed to:
https://github.com/immutant/immutant/blob/master/docs/src/main/clojure/immutant/docs/autodoc.clj

If there is a better way to solve the multiproject doc problem, I'm certainly open to that.
